### PR TITLE
Update encoder go removing buggy hash include

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -1,9 +1,9 @@
 package lame
 
 /*
-#cgo LDFLAGS: -lmp3lame
-#include <lame/lame.h>
-*/
+ * cgo LDFLAGS: -lmp3lame
+ * include <lame/lame.h>
+ */
 import "C"
 
 import (


### PR DESCRIPTION
# Bugfix:
- Fixes https://github.com/viert/go-lame/issues/2