### PR TITLE
handle errors from flush to avoid possible panics

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -332,7 +332,10 @@ func (e *Encoder) Flush() (n int, err error) {
 		co,
 		C.int(estimatedSize),
 	))
-	if bytesOut != 0 {
+	if bytesOut < 0 {
+		n = 0
+		err = convError(n)
+	} else if bytesOut != 0 {
 		n, err = e.output.Write(o[:bytesOut])
 	} else {
 		n = 0


### PR DESCRIPTION
I encountered occasional panics due to `lame_encode_flush` returning `-3`. I think this is due to the `finalizer` calling `e.Close` directly and then `Close` being called afterward.